### PR TITLE
chore: Fix typo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/stm32f072x-memory-map"
 keywords = ["arm", "cortex-m", "cortex-m0", "stm32"]
 license = "MIT OR Apache-2.0"
 version = "0.1.0"
-category = ["embedded", "hardware-support", "memory-management", "no-std"]
+categories = ["embedded", "hardware-support", "memory-management", "no-std"]
 repository = "https://github.com/samdolt/stm32f072x-memory-map"
 
 [dependencies]


### PR DESCRIPTION
Given the most recent change here I know it is unlikely you will publish a new version of this crate on crates.io, but in case you do you might want to fix this typo in `Cargo.toml`. See https://github.com/szabgab/rust-digger/issues/100